### PR TITLE
Fixed log4j

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Set root logger level to error
-log4j.rootLogger=INFO,error, Console, File
+log4j.rootLogger=INFO, Console, File
 
 
 ###### Console appender definition #######


### PR DESCRIPTION
Errors are not visible in logs if encountered.
